### PR TITLE
style: darken list hover/selection highlights for readability

### DIFF
--- a/src/lib/ui.rs
+++ b/src/lib/ui.rs
@@ -9,6 +9,12 @@ use crate::app::{App, View};
 use crate::clock::Clock;
 use crate::task::TaskState;
 
+// Theme: darker list highlights for better contrast with default light (white) text.
+// These colors aim to keep contrast acceptable on common terminals while avoiding
+// the eye‑searing effect of bright Blue/Cyan backgrounds.
+pub const SELECTED_ROW_BG: Color = Color::Rgb(0, 60, 120); // dark blue
+pub const HOVER_ROW_BG: Color = Color::Rgb(0, 100, 100); // dark cyan/teal
+
 const MIN_LIST_LINES: u16 = 3; // table header + at least two rows
 
 pub fn draw(f: &mut Frame, app: &App) {
@@ -516,9 +522,9 @@ fn build_task_table(now_min: u16, app: &App, tasks_slice: &[crate::task::Task]) 
             }
         ));
         let highlight_bg = if i == selected {
-            Some(Color::Blue)
+            Some(SELECTED_ROW_BG)
         } else if hovered == Some(i) {
-            Some(Color::Cyan)
+            Some(HOVER_ROW_BG)
         } else {
             None
         };

--- a/tests/ui_hover_highlight_test.rs
+++ b/tests/ui_hover_highlight_test.rs
@@ -18,26 +18,25 @@ fn hover_row_renders_in_cyan_while_selection_stays_blue() {
     app.handle_mouse_move(col_x, row_y, area);
     assert_eq!(app.hovered_index(), Some(1), "hovered index should be 1 after mouse move");
 
-    // Draw and assert: row 0 (selected) is Blue; row 1 (hover) is Cyan
-    use ratatui::style::Color;
+    // Draw and assert: row 0 (selected) has selected highlight BG; row 1 (hover) has hover BG
     terminal.draw(|f| ui::draw(f, &app)).unwrap();
     let buf = terminal.backend().buffer();
     let list_y_top = list.y; // table header at list.y; first data row at list.y + 1
-                             // Selected row (index 0) should have Blue background somewhere across the row
+                             // Selected row (index 0) should have background somewhere across the row
     let mut blue_found = false;
     for x in list.x..list.x + list.width.min(buf.area.width) {
-        if buf[(x, list_y_top + 1)].style().bg == Some(Color::Blue) {
+        if buf[(x, list_y_top + 1)].style().bg == Some(ui::SELECTED_ROW_BG) {
             blue_found = true;
             break;
         }
     }
-    assert!(blue_found, "selected row should be Blue across at least one cell");
+    assert!(blue_found, "selected row should use SELECTED_ROW_BG across at least one cell");
 
     // Hover row (index 1) should have Cyan background somewhere across the row
     let mut cyan_found = false;
     for x in list.x..list.x + list.width.min(buf.area.width) {
         let cell = &buf[(x, list_y_top + 2)];
-        if cell.style().bg == Some(Color::Cyan) {
+        if cell.style().bg == Some(ui::HOVER_ROW_BG) {
             cyan_found = true;
             break;
         }
@@ -49,16 +48,16 @@ fn hover_row_renders_in_cyan_while_selection_stays_blue() {
         for x in 0..buf.area.width {
             row_chars.push_str(buf[(x, list_y_top + 2)].symbol());
             row_styles.push_str(match buf[(x, list_y_top + 2)].style().bg {
-                Some(Color::Blue) => "B",
-                Some(Color::Cyan) => "C",
+                Some(c) if c == ui::SELECTED_ROW_BG => "B",
+                Some(c) if c == ui::HOVER_ROW_BG => "C",
                 Some(_) => "*",
                 None => ".",
             });
         }
         panic!(
-            "hover row not Cyan. chars='{}' styles='{}' list=({},{},{},{})",
+            "hover row not HOVER_ROW_BG. chars='{}' styles='{}' list=({},{},{},{})",
             row_chars, row_styles, list.x, list.y, list.width, list.height
         );
     }
-    assert!(cyan_found, "hover row should be Cyan across at least one cell");
+    assert!(cyan_found, "hover row should use HOVER_ROW_BG across at least one cell");
 }


### PR DESCRIPTION
Problem
- Selected(Blue)・Hover(Cyan) の背景が明るく、白文字とのコントラストが低い環境で視認性が悪い。

Decision
- 文字色の反転ではなく、背景色を暗くするアプローチを採用。
  - 端末配色に依存せず比較的一貫した視認性を確保しやすい。

Changes
- 新規テーマ定数: `SELECTED_ROW_BG = Rgb(0,60,120)`, `HOVER_ROW_BG = Rgb(0,100,100)`
- リスト行の選択/ホバーにこれらを適用（文字色は既定の白を維持）
- テスト更新: `ui_hover_highlight_test` を新しいテーマ定数で検証

Notes
- タブのホバー（前景Cyan）とヘッダのスタイルは現状維持。
- 追加のテーマ切替や設定化は別PRで検討可能。

Verification
- pre-commit（fmt+clippy）/ 全テストOK。
